### PR TITLE
Add Bulgarian (enhanced) keyboard layout

### DIFF
--- a/java/res/values/donottranslate.xml
+++ b/java/res/values/donottranslate.xml
@@ -81,6 +81,9 @@
     <!-- Description for Bulgarian (BDS) subtype. -->
     <string name="subtype_bulgarian_bds">%s (BDS)</string>
 
+    <!-- Description for Bulgarian (BEKL) subtype. -->
+    <string name="subtype_bulgarian_bekl">%s (BEKL)</string>
+
     <!-- Compatibility map from subtypeLocale:subtypeExtraValue to keyboardLayoutSet -->
     <string-array name="locale_and_extra_value_to_keyboard_layout_set_map">
         <item>en_US:TrySuppressingImeSwitcher,AsciiCapable,SupportTouchPositionCorrection,EmojiCapable</item>

--- a/java/res/xml/kbd_bulgarian_bekl.xml
+++ b/java/res/xml/kbd_bulgarian_bekl.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License"):
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<Keyboard
+    xmlns:latin="http://schemas.android.com/apk/res/com.android.inputmethod.latin"
+>
+    <include
+        latin:keyboardLayout="@xml/rows_bulgarian_bekl" />
+</Keyboard>

--- a/java/res/xml/keyboard_layout_set_bulgarian_bekl.xml
+++ b/java/res/xml/keyboard_layout_set_bulgarian_bekl.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<KeyboardLayoutSet
+    xmlns:latin="http://schemas.android.com/apk/res/com.android.inputmethod.latin">
+    <Feature
+        latin:supportedScript="cyrillic" />
+    <Element
+        latin:elementName="alphabet"
+        latin:elementKeyboard="@xml/kbd_bulgarian_bekl"
+        latin:enableProximityCharsCorrection="true" />
+    <Element
+        latin:elementName="symbols"
+        latin:elementKeyboard="@xml/kbd_symbols" />
+    <Element
+        latin:elementName="symbolsShifted"
+        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+    <Element
+        latin:elementName="phone"
+        latin:elementKeyboard="@xml/kbd_phone" />
+    <Element
+        latin:elementName="phoneSymbols"
+        latin:elementKeyboard="@xml/kbd_phone_symbols" />
+    <Element
+        latin:elementName="number"
+        latin:elementKeyboard="@xml/kbd_number" />
+</KeyboardLayoutSet>

--- a/java/res/xml/method.xml
+++ b/java/res/xml/method.xml
@@ -28,6 +28,7 @@
     be_BY: Belarusian (Belarus)/east_slavic
     bg: Bulgarian/bulgarian
     bg: Bulgarian/bulgarian_bds
+    bg: Bulgarian/bulgarian_bekl
     bn_BD: Bengali (Bangladesh)/bengali_akkhor
     bn_IN: Bengali (India)/bengali
     ca: Catalan/spanish
@@ -190,6 +191,14 @@
             android:imeSubtypeLocale="bg"
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=bulgarian_bds,EmojiCapable"
+            android:isAsciiCapable="false"
+    />
+    <subtype android:icon="@drawable/ic_ime_switcher_dark"
+            android:label="@string/subtype_bulgarian_bekl"
+            android:subtypeId="0x6242587e"
+            android:imeSubtypeLocale="bg"
+            android:imeSubtypeMode="keyboard"
+            android:imeSubtypeExtraValue="KeyboardLayoutSet=bulgarian_bekl,EmojiCapable"
             android:isAsciiCapable="false"
     />
     <subtype android:icon="@drawable/ic_ime_switcher_dark"

--- a/java/res/xml/rowkeys_bulgarian_bekl1.xml
+++ b/java/res/xml/rowkeys_bulgarian_bekl1.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res/com.android.inputmethod.latin"
+>
+    <!-- U+0443: "у" CYRILLIC SMALL LETTER U -->
+    <Key
+        latin:keySpec="&#x0443;"
+        latin:keyHintLabel="1"
+        latin:additionalMoreKeys="1" />
+    <!-- U+0435: "е" CYRILLIC SMALL LETTER IE -->
+    <Key
+        latin:keySpec="&#x0435;"
+        latin:keyHintLabel="2"
+        latin:additionalMoreKeys="2" />
+    <!-- U+0438: "и" CYRILLIC SMALL LETTER I
+         U+045D: "ѝ" CYRILLIC SMALL LETTER I WITH GRAVE -->
+    <Key
+        latin:keySpec="&#x0438;"
+        latin:keyHintLabel="3"
+        latin:additionalMoreKeys="3"
+        latin:moreKeys="&#x045D;" />
+    <!-- U+0448: "ш" CYRILLIC SMALL LETTER SHA -->
+    <Key
+        latin:keySpec="&#x0448;"
+        latin:keyHintLabel="4"
+        latin:additionalMoreKeys="4" />
+    <!-- U+0449: "щ" CYRILLIC SMALL LETTER SHCHA -->
+    <Key
+        latin:keySpec="&#x0449;"
+        latin:keyHintLabel="5"
+        latin:additionalMoreKeys="5" />
+    <!-- U+043A: "к" CYRILLIC SMALL LETTER KA -->
+    <Key
+        latin:keySpec="&#x043A;"
+        latin:keyHintLabel="6"
+        latin:additionalMoreKeys="6" />
+    <!-- U+0441: "с" CYRILLIC SMALL LETTER ES -->
+    <Key
+        latin:keySpec="&#x0441;"
+        latin:keyHintLabel="7"
+        latin:additionalMoreKeys="7" />
+    <!-- U+0434: "д" CYRILLIC SMALL LETTER DE -->
+    <Key
+        latin:keySpec="&#x0434;"
+        latin:keyHintLabel="8"
+        latin:additionalMoreKeys="8" />
+    <!-- U+0437: "з" CYRILLIC SMALL LETTER ZE -->
+    <Key
+        latin:keySpec="&#x0437;"
+        latin:keyHintLabel="9"
+        latin:additionalMoreKeys="9" />
+    <!-- U+0446: "ц" CYRILLIC SMALL LETTER TSE -->
+    <Key
+        latin:keySpec="&#x0446;"
+        latin:keyHintLabel="0"
+        latin:additionalMoreKeys="0" />
+    <!-- U+0431: "б" CYRILLIC SMALL LETTER BE -->
+    <Key
+        latin:keySpec="&#x0431;" />
+</merge>

--- a/java/res/xml/rowkeys_bulgarian_bekl2.xml
+++ b/java/res/xml/rowkeys_bulgarian_bekl2.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res/com.android.inputmethod.latin"
+>
+    <!-- U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN -->
+    <Key
+        latin:keySpec="&#x044C;" />
+    <!-- U+044F: "я" CYRILLIC SMALL LETTER YA -->
+    <Key
+        latin:keySpec="&#x044F;" />
+    <!-- U+0430: "а" CYRILLIC SMALL LETTER A -->
+    <Key
+        latin:keySpec="&#x0430;" />
+    <!-- U+043E: "о" CYRILLIC SMALL LETTER O -->
+    <Key
+        latin:keySpec="&#x043E;" />
+    <!-- U+0436: "ж" CYRILLIC SMALL LETTER ZHE -->
+    <Key
+        latin:keySpec="&#x0436;" />
+    <!-- U+0433: "г" CYRILLIC SMALL LETTER GHE -->
+    <Key
+        latin:keySpec="&#x0433;" />
+    <!-- U+0442: "т" CYRILLIC SMALL LETTER TE -->
+    <Key
+        latin:keySpec="&#x0442;" />
+    <!-- U+043D: "н" CYRILLIC SMALL LETTER EN -->
+    <Key
+        latin:keySpec="&#x043D;" />
+    <!-- U+0432: "в" CYRILLIC SMALL LETTER VE -->
+    <Key
+        latin:keySpec="&#x0432;" />
+    <!-- U+043C: "м" CYRILLIC SMALL LETTER EM -->
+    <Key
+        latin:keySpec="&#x043C;" />
+    <!-- U+0447: "ч" CYRILLIC SMALL LETTER CHE -->
+    <Key
+        latin:keySpec="&#x0447;" />
+</merge>

--- a/java/res/xml/rowkeys_bulgarian_bekl3.xml
+++ b/java/res/xml/rowkeys_bulgarian_bekl3.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res/com.android.inputmethod.latin"
+>
+    <!-- U+044E: "ю" CYRILLIC SMALL LETTER YU -->
+    <Key
+        latin:keySpec="&#x044E;" />
+    <!-- U+0439: "й" CYRILLIC SMALL LETTER SHORT I
+         U+046D: "ѭ" CYRILLIC SMALL LETTER IOTIFIED BIG YUS -->
+    <Key
+        latin:keySpec="&#x0439;"
+        latin:keyHintLabel="ѭ"
+        latin:moreKeys="&#x046D;" />
+    <!-- U+044A: "ъ" CYRILLIC SMALL LETTER HARD SIGN
+         U+046B: "ѫ" CYRILLIC SMALL LETTER BIG YUS -->
+    <Key
+        latin:keySpec="&#x044A;"
+        latin:keyHintLabel="ѫ"
+        latin:moreKeys="&#x046B;" />
+    <!-- U+0463: "ѣ" CYRILLIC SMALL LETTER YAT -->
+    <Key
+        latin:keySpec="&#x0463;" />
+    <!-- U+0444: "ф" CYRILLIC SMALL LETTER EF -->
+    <Key
+        latin:keySpec="&#x0444;" />
+    <!-- U+0445: "х" CYRILLIC SMALL LETTER HA -->
+    <Key
+        latin:keySpec="&#x0445;" />
+    <!-- U+043F: "п" CYRILLIC SMALL LETTER PE -->
+    <Key
+        latin:keySpec="&#x043F;" />
+    <!-- U+0440: "р" CYRILLIC SMALL LETTER ER -->
+    <Key
+        latin:keySpec="&#x0440;" />
+    <!-- U+043B: "л" CYRILLIC SMALL LETTER EL -->
+    <Key
+        latin:keySpec="&#x043B;" />
+</merge>

--- a/java/res/xml/rows_bulgarian_bekl.xml
+++ b/java/res/xml/rows_bulgarian_bekl.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res/com.android.inputmethod.latin"
+>
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+    <Row
+        latin:keyWidth="9.091%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_bulgarian_bekl1" />
+    </Row>
+    <Row
+            latin:keyWidth="9.091%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_bulgarian_bekl2" />
+    </Row>
+    <Row
+        latin:keyWidth="8.711%p"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="10.8%p" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_bulgarian_bekl3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <include
+        latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>

--- a/tests/src/com/android/inputmethod/keyboard/layout/BulgarianBekl.java
+++ b/tests/src/com/android/inputmethod/keyboard/layout/BulgarianBekl.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.inputmethod.keyboard.layout;
+
+import com.android.inputmethod.keyboard.layout.customizer.EastSlavicCustomizer;
+import com.android.inputmethod.keyboard.layout.expected.ExpectedKey;
+import com.android.inputmethod.keyboard.layout.expected.ExpectedKeyboardBuilder;
+
+import java.util.Locale;
+
+public final class BulgarianBekl extends LayoutBase {
+    private static final String LAYOUT_NAME = "bulgarian_bekl";
+
+    public BulgarianBekl(final Locale locale) {
+        super(new BulgarianBeklCustomizer(locale), Symbols.class, SymbolsShifted.class);
+    }
+
+    @Override
+    public String getName() { return LAYOUT_NAME; }
+
+    private static class BulgarianBeklCustomizer extends EastSlavicCustomizer {
+        BulgarianBeklCustomizer(final Locale locale) { super(locale); }
+
+        @Override
+        public ExpectedKey[] getDoubleQuoteMoreKeys() { return Symbols.DOUBLE_QUOTES_R9L; }
+    }
+
+    @Override
+    ExpectedKey[][] getCommonAlphabetLayout(final boolean isPhone) { return ALPHABET_COMMON; }
+
+    private static final ExpectedKey[][] ALPHABET_COMMON = new ExpectedKeyboardBuilder()
+            .setKeysOfRow(1,
+                    // U+0443: "у" CYRILLIC SMALL LETTER U
+                    key("\u0443", moreKey("1")),
+                    // U+0435: "е" CYRILLIC SMALL LETTER IE
+                    key("\u0435", moreKey("2")),
+                    // U+0438: "и" CYRILLIC SMALL LETTER I
+                    // U+045D: "ѝ" CYRILLIC SMALL LETTER I WITH GRAVE
+                    key("\u0438", joinMoreKeys("3", "\u045D")),
+                    // U+0448: "ш" CYRILLIC SMALL LETTER SHA
+                    key("\u0448", moreKey("4")),
+                    // U+0449: "щ" CYRILLIC SMALL LETTER SHCHA
+                    key("\u0449", moreKey("5")),
+                    // U+043A: "к" CYRILLIC SMALL LETTER KA
+                    key("\u043A", moreKey("6")),
+                    // U+0441: "с" CYRILLIC SMALL LETTER ES
+                    key("\u0441", moreKey("7")),
+                    // U+0434: "д" CYRILLIC SMALL LETTER DE
+                    key("\u0434", moreKey("8")),
+                    // U+0437: "з" CYRILLIC SMALL LETTER ZE
+                    key("\u0437", moreKey("9")),
+                    // U+0446: "ц" CYRILLIC SMALL LETTER TSE
+                    key("\u0446", moreKey("0")),
+                    // U+0431: "б" CYRILLIC SMALL LETTER BE
+                    "\u0431")
+            .setKeysOfRow(2,
+                    // U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN
+                    // U+044F: "я" CYRILLIC SMALL LETTER YA
+                    // U+0430: "а" CYRILLIC SMALL LETTER A
+                    // U+043E: "о" CYRILLIC SMALL LETTER O
+                    // U+0436: "ж" CYRILLIC SMALL LETTER ZHE
+                    // U+0433: "г" CYRILLIC SMALL LETTER GHE
+                    // U+0442: "т" CYRILLIC SMALL LETTER TE
+                    // U+043D: "н" CYRILLIC SMALL LETTER EN
+                    // U+0432: "в" CYRILLIC SMALL LETTER VE
+                    // U+043C: "м" CYRILLIC SMALL LETTER EM
+                    // U+0447: "ч" CYRILLIC SMALL LETTER CHE
+                    "\u044C", "\u044F", "\u0430", "\u043E", "\u0436", "\u0433", "\u0442", "\u043D",
+                    "\u0432", "\u043C", "\u0447")
+            .setKeysOfRow(3,
+                    // U+044E: "ю" CYRILLIC SMALL LETTER YU
+                    // U+0439: "й" CYRILLIC SMALL LETTER SHORT I
+                    // U+046D: "ѭ" CYRILLIC SMALL LETTER IOTIFIED BIG YUS
+                    // U+044A: "ъ" CYRILLIC SMALL LETTER HARD SIGN
+					// U+046B: "ѫ" CYRILLIC SMALL LETTER BIG YUS
+                    // U+0463: "ѣ" CYRILLIC SMALL LETTER YAT
+                    // U+0444: "ф" CYRILLIC SMALL LETTER EF
+                    // U+0445: "х" CYRILLIC SMALL LETTER HA
+                    // U+043F: "п" CYRILLIC SMALL LETTER PE
+                    // U+0440: "р" CYRILLIC SMALL LETTER ER
+                    // U+043B: "л" CYRILLIC SMALL LETTER EL
+                    "\u044E", key("\u0439", moreKey("\u046D")), key("\u044A", moreKey("\u046B")), "\u0463", "\u0444", "\u0445", "\u043F", "\u0440",
+                    "\u043B")
+            .build();
+}

--- a/tests/src/com/android/inputmethod/keyboard/layout/tests/TestsBulgarianBekl.java
+++ b/tests/src/com/android/inputmethod/keyboard/layout/tests/TestsBulgarianBekl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.inputmethod.keyboard.layout.tests;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import com.android.inputmethod.keyboard.layout.BulgarianBekl;
+import com.android.inputmethod.keyboard.layout.LayoutBase;
+
+import java.util.Locale;
+
+/**
+ * bg: Bulgarian/bulgarian_bekl
+ */
+@SmallTest
+public final class TestsBulgarianBekl extends LayoutTestsBase {
+    private static final Locale LOCALE = new Locale("bg");
+    private static final LayoutBase LAYOUT = new BulgarianBekl(LOCALE);
+
+    @Override
+    LayoutBase getLayout() { return LAYOUT; }
+}


### PR DESCRIPTION
An enhanced variant of the Bulgarian BDS keyboard, proposed in May 2020 by a group of more than 500 linguists, teachers, writers, translators, IT specialists, professors and many more.